### PR TITLE
Fix collision of class names between namespaces

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -328,7 +328,9 @@ abstract class AbstractOMBuilder extends DataModelBuilder
                 //so use the fqcn
                 return ($namespace ? '\\' . $namespace : '') .  '\\' . $class;
             } else {
-                $autoAliasName = 'Child' . $class;
+                // $autoAliasName = 'Child' . $class;
+                // FIXME: USE A DIFFERENT SYSTEM TO GENERATE AN UNIQUE NAME FOR THIS CLASS?
+                $autoAliasName = $class . md5($namespace);
             }
 
             return $this->declareClassNamespace($class, $namespace, $autoAliasName);
@@ -378,6 +380,11 @@ abstract class AbstractOMBuilder extends DataModelBuilder
             if (false === array_search($class, $this->whiteListOfDeclaredClasses, true)) {
                 return true;
             }
+        }
+        
+        if (isset($this->declaredClasses[$this->getNamespace()][$class]) || isset($this->declaredClasses[$this->getNamespace()][str_replace("Query", "", $class)])) {
+            // classes that are already declared must be aliased to prevent collisions between namespaces
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Fixes an use case like this one:
<database name="default" defaultIdMethod="native" defaultPhpNamingMethod="underscore" namespace="Database">
  <table name="arclabs_accounts" idMethod="native" phpName="Account" namespace="ArcLaboratories">
    [...]
  </table>
  <table name="mlabs_accounts" idMethod="native" phpName="Account" namespace="MinecraftLaboratories">
    [...]
  </table>
</database>